### PR TITLE
Issue https://github.com/ainilili/ratel/issues/15 fixed.

### DIFF
--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_CLIENT_NICKNAME_SET.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_CLIENT_NICKNAME_SET.java
@@ -1,6 +1,11 @@
 package org.nico.ratel.landlords.client.event;
 
+import java.util.Map;
+
+import org.nico.noson.util.string.StringUtils;
+import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.enums.ServerEventCode;
+import org.nico.ratel.landlords.helper.MapHelper;
 import org.nico.ratel.landlords.print.SimplePrinter;
 import org.nico.ratel.landlords.print.SimpleWriter;
 
@@ -8,10 +13,27 @@ import io.netty.channel.Channel;
 
 public class ClientEventListener_CODE_CLIENT_NICKNAME_SET extends ClientEventListener{
 
+	public static final int NICKNAME_MAX_LENGTH = 10;
+	
 	@Override
 	public void call(Channel channel, String data) {
-		SimplePrinter.printNotice("Please set your nickname");
+		
+		// If it is not the first time that the user is prompted to enter nickname
+		// If first time, data = null or "" otherwise not empty
+		if (StringUtils.isNotBlank(data)) {
+			Map<String, Object> dataMap = MapHelper.parser(data);
+			if (dataMap.containsKey("invalidLength")) {
+				SimplePrinter.printNotice("Your nickname length was invalid: " + dataMap.get("invalidLength"));
+			}
+		}
+		SimplePrinter.printNotice("Please set your nickname (upto " + NICKNAME_MAX_LENGTH + " characters)");
 		String nickname = SimpleWriter.write("nickname");
+		
+		// If the length of nickname is more that NICKNAME_MAX_LENGTH
+		if (nickname.trim().length() > NICKNAME_MAX_LENGTH) {
+			String result = MapHelper.newInstance().put("invalidLength", nickname.trim().length()).json();
+			get(ClientEventCode.CODE_CLIENT_NICKNAME_SET).call(channel, result);
+		}
 		pushToServer(channel, ServerEventCode.CODE_CLIENT_NICKNAME_SET, nickname);
 	}
 

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_SETTING.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_SETTING.java
@@ -31,7 +31,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS_SETTING extends ClientEventLi
 			}
 			
 			int choose = Integer.valueOf(line);
-			if(choose >=1 && choose <= PokerHelper.totalPrinters){
+			if(choose >=1 && choose <= 5){
 				PokerHelper.pokerPrinterType = choose - 1;
 				get(ClientEventCode.CODE_SHOW_OPTIONS).call(channel, data);
 			} else {

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_ROOMS.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_ROOMS.java
@@ -1,11 +1,13 @@
 package org.nico.ratel.landlords.client.event;
 
+import static org.nico.ratel.landlords.client.event.ClientEventListener_CODE_CLIENT_NICKNAME_SET.NICKNAME_MAX_LENGTH;
 import java.util.List;
 import java.util.Map;
 
 import org.nico.noson.Noson;
 import org.nico.noson.entity.NoType;
 import org.nico.ratel.landlords.enums.ClientEventCode;
+import org.nico.ratel.landlords.print.FormatPrinter;
 import org.nico.ratel.landlords.print.SimplePrinter;
 
 import io.netty.channel.Channel;
@@ -17,9 +19,11 @@ public class ClientEventListener_CODE_SHOW_ROOMS extends ClientEventListener{
 		
 		List<Map<String, Object>> roomList = Noson.convert(data, new NoType<List<Map<String, Object>>>() {});
 		if(roomList != null && ! roomList.isEmpty()){
-			SimplePrinter.printNotice("#\tID\t|\tOWNER\t|\tCOUNT\t#");
+			// "COUNT" begins after NICKNAME_MAX_LENGTH characters. The dash means that the string is left-justified.
+			String format = "#\t%s\t|\t%-" + NICKNAME_MAX_LENGTH + "s\t|\t%s\t#\n";
+			FormatPrinter.printNotice(format, "ID", "OWNER", "COUNT");
 			for(Map<String, Object> room: roomList) {
-				SimplePrinter.printNotice("#\t" + room.get("roomId") + "\t|\t" + room.get("roomOwner") + "\t|\t" + room.get("roomClientCount") + "\t#");
+				FormatPrinter.printNotice(format, room.get("roomId"), room.get("roomOwner"), room.get("roomClientCount"));
 			}
 			SimplePrinter.printNotice("");
 			get(ClientEventCode.CODE_SHOW_OPTIONS).call(channel, data);

--- a/landlords-common/src/main/java/org/nico/ratel/landlords/print/FormatPrinter.java
+++ b/landlords-common/src/main/java/org/nico/ratel/landlords/print/FormatPrinter.java
@@ -1,0 +1,11 @@
+package org.nico.ratel.landlords.print;
+
+public class FormatPrinter {
+
+	private FormatPrinter() {
+	}
+
+	public static void printNotice(String format, Object... args) {
+		System.out.printf(format, args);
+	}
+}


### PR DESCRIPTION
Max length for nickname restricted to 10 characters and with proper formatting. RoomList now has a proper printing format according to the nickname's max length.