### PR TITLE
[ratel] add nickname to terminal

### DIFF
--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/SimpleClient.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/SimpleClient.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.nico.noson.Noson;
 import org.nico.noson.entity.NoType;
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.client.proxy.ProtobufProxy;
 import org.nico.ratel.landlords.client.proxy.WebsocketProxy;
 import org.nico.ratel.landlords.features.Features;
@@ -62,11 +63,11 @@ public class SimpleClient {
 			for (int i = 0; i < serverAddressList.size(); i++) {
 				SimplePrinter.printNotice((i + 1) + ". " + serverAddressList.get(i));
 			}
-			int serverPick = Integer.parseInt(SimpleWriter.write("option"));
+			int serverPick = Integer.parseInt(SimpleWriter.write(User.INSTANCE.getNickname(), "option"));
 			while (serverPick < 1 || serverPick > serverAddressList.size()) {
 				try {
 					SimplePrinter.printNotice("The server address does not exist!");
-					serverPick = Integer.parseInt(SimpleWriter.write("option"));
+					serverPick = Integer.parseInt(SimpleWriter.write(User.INSTANCE.getNickname(), "option"));
 				} catch (NumberFormatException ignore) {}
 			}
 			serverAddress = serverAddressList.get(serverPick - 1);

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/entity/User.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/entity/User.java
@@ -9,6 +9,8 @@ public class User {
     /** 是否观战中 */
     private volatile boolean isWatching = false;
 
+    private String nickname = "player";
+
     private User() {}
 
     public boolean isPlaying() {
@@ -25,5 +27,13 @@ public class User {
 
     public void setWatching(boolean watching) {
         isWatching = watching;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener.java
@@ -2,6 +2,7 @@ package org.nico.ratel.landlords.client.event;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.nico.ratel.landlords.channel.ChannelUtils;
@@ -37,7 +38,7 @@ public abstract class ClientEventListener {
 			if (ClientEventListener.LISTENER_MAP.containsKey(code)) {
 				listener = ClientEventListener.LISTENER_MAP.get(code);
 			} else {
-				String eventListener = LISTENER_PREFIX + code.name();
+				String eventListener = LISTENER_PREFIX + code.name().toUpperCase(Locale.ROOT);
 				Class<ClientEventListener> listenerClass = (Class<ClientEventListener>) Class.forName(eventListener);
 				listener = listenerClass.newInstance();
 				ClientEventListener.LISTENER_MAP.put(code, listener);

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_CLIENT_NICKNAME_SET.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_CLIENT_NICKNAME_SET.java
@@ -3,6 +3,7 @@ package org.nico.ratel.landlords.client.event;
 import java.util.Map;
 
 import org.nico.noson.util.string.StringUtils;
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.enums.ServerEventCode;
 import org.nico.ratel.landlords.helper.MapHelper;
@@ -27,7 +28,7 @@ public class ClientEventListener_CODE_CLIENT_NICKNAME_SET extends ClientEventLis
 			}
 		}
 		SimplePrinter.printNotice("Please set your nickname (upto " + NICKNAME_MAX_LENGTH + " characters)");
-		String nickname = SimpleWriter.write("nickname");
+		String nickname = SimpleWriter.write(User.INSTANCE.getNickname(), "nickname");
 
 		// If the length of nickname is more that NICKNAME_MAX_LENGTH
 		if (nickname.trim().length() > NICKNAME_MAX_LENGTH) {
@@ -35,6 +36,7 @@ public class ClientEventListener_CODE_CLIENT_NICKNAME_SET extends ClientEventLis
 			get(ClientEventCode.CODE_CLIENT_NICKNAME_SET).call(channel, result);
 		} else {
 			pushToServer(channel, ServerEventCode.CODE_CLIENT_NICKNAME_SET, nickname);
+			User.INSTANCE.setNickname(nickname);
 		}
 	}
 

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_LANDLORD_ELECT.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_LANDLORD_ELECT.java
@@ -3,6 +3,7 @@ package org.nico.ratel.landlords.client.event;
 import java.util.Map;
 
 import org.nico.ratel.landlords.client.SimpleClient;
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ServerEventCode;
 import org.nico.ratel.landlords.helper.MapHelper;
 import org.nico.ratel.landlords.print.SimplePrinter;
@@ -23,7 +24,7 @@ public class ClientEventListener_CODE_GAME_LANDLORD_ELECT extends ClientEventLis
 
 		if(turnClientId == SimpleClient.id) {
 			SimplePrinter.printNotice("It's your turn. Do you want to rob the landlord? [Y/N] (enter [exit|e] to exit current room)");
-			String line = SimpleWriter.write("Y/N");
+			String line = SimpleWriter.write(User.INSTANCE.getNickname(), "Y/N");
 			if (line.equalsIgnoreCase("exit") || line.equalsIgnoreCase("e")) {
 				pushToServer(channel, ServerEventCode.CODE_CLIENT_EXIT);
 			} else if (line.equalsIgnoreCase("Y")) {

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_POKER_PLAY.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_POKER_PLAY.java
@@ -4,6 +4,7 @@ import io.netty.channel.Channel;
 import org.nico.noson.Noson;
 import org.nico.noson.entity.NoType;
 import org.nico.ratel.landlords.client.SimpleClient;
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.entity.Poker;
 import org.nico.ratel.landlords.entity.PokerSell;
 import org.nico.ratel.landlords.enums.PokerLevel;
@@ -31,7 +32,7 @@ public class ClientEventListener_CODE_GAME_POKER_PLAY extends ClientEventListene
 		SimplePrinter.printNotice(map.containsKey("lastPokers")?map.get("lastPokers").toString():"");
 
 		SimplePrinter.printNotice("Please enter the combination you came up with (enter [exit|e] to exit current room, enter [pass|p] to jump current round, enter [view|v] to show all valid combinations.)");
-		String line = SimpleWriter.write("combination");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "combination");
 
 		if (line == null) {
 			SimplePrinter.printNotice("Invalid enter");
@@ -65,7 +66,7 @@ public class ClientEventListener_CODE_GAME_POKER_PLAY extends ClientEventListene
 					}
 					while (true) {
 						SimplePrinter.printNotice("You can enter index to choose anyone.(enter [back|b] to go back.)");
-						line = SimpleWriter.write("choose");
+						line = SimpleWriter.write(User.INSTANCE.getNickname(), "choose");
 						if (line.equalsIgnoreCase("back") || line.equalsIgnoreCase("b")) {
 							call(channel, data);
 							return;

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_READY.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_GAME_READY.java
@@ -3,6 +3,7 @@ package org.nico.ratel.landlords.client.event;
 import io.netty.channel.Channel;
 import org.nico.ratel.landlords.channel.ChannelUtils;
 import org.nico.ratel.landlords.client.SimpleClient;
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ServerEventCode;
 import org.nico.ratel.landlords.helper.MapHelper;
 import org.nico.ratel.landlords.print.SimplePrinter;
@@ -23,7 +24,7 @@ public class ClientEventListener_CODE_GAME_READY extends ClientEventListener {
 
     static void gameReady(Channel channel) {
         SimplePrinter.printNotice("\nDo you want to continue the game? [Y/N]");
-        String line = SimpleWriter.write("notReady");
+        String line = SimpleWriter.write(User.INSTANCE.getNickname(), "notReady");
         if (line.equals("Y") || line.equals("y")) {
             ChannelUtils.pushToServer(channel, ServerEventCode.CODE_GAME_READY, "");
             return;

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS.java
@@ -1,5 +1,6 @@
 package org.nico.ratel.landlords.client.event;
 
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.print.SimplePrinter;
 import org.nico.ratel.landlords.print.SimpleWriter;
@@ -16,7 +17,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS extends ClientEventListener {
 		SimplePrinter.printNotice("2. PvE");
 		SimplePrinter.printNotice("3. Settings");
 		SimplePrinter.printNotice("Please select an option above (enter [exit|e] to log out)");
-		String line = SimpleWriter.write("selection");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "selection");
 
 		if(line.equalsIgnoreCase("exit") || line.equalsIgnoreCase("e")) {
 			System.exit(0);

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_PVE.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_PVE.java
@@ -1,5 +1,6 @@
 package org.nico.ratel.landlords.client.event;
 
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.enums.ServerEventCode;
 import org.nico.ratel.landlords.print.SimplePrinter;
@@ -17,7 +18,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS_PVE extends ClientEventListen
 		SimplePrinter.printNotice("2. Medium Mode");
 		SimplePrinter.printNotice("3. Hard Mode");
 		SimplePrinter.printNotice("Please select an option above (enter [back|b] to return to options list)");
-		String line = SimpleWriter.write("pve");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "pve");
 
 		if(line.equalsIgnoreCase("back") ||  line.equalsIgnoreCase("b")) {
 			get(ClientEventCode.CODE_SHOW_OPTIONS).call(channel, data);

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_PVP.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_PVP.java
@@ -1,5 +1,6 @@
 package org.nico.ratel.landlords.client.event;
 
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.enums.ServerEventCode;
 import org.nico.ratel.landlords.print.SimplePrinter;
@@ -18,7 +19,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS_PVP extends ClientEventListen
 		SimplePrinter.printNotice("3. Join Room");
 		SimplePrinter.printNotice("4. Spectate Game");
 		SimplePrinter.printNotice("Please select an option above (enter [back|b] to return to options list)");
-		String line = SimpleWriter.write("pvp");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "pvp");
 		if (line == null) {
 			SimplePrinter.printNotice("Invalid options, please choose again：");
 			call(channel, data);
@@ -63,7 +64,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS_PVP extends ClientEventListen
 		String notice = String.format("Please enter the room id you want to %s (enter [back|b] return options list)", watchMode ? "spectate" : "join");
 
 		SimplePrinter.printNotice(notice);
-		String line = SimpleWriter.write("roomid");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "roomid");
 		if (line == null) {
 			parseInvalid(channel, data);
 			return;

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_SETTING.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/event/ClientEventListener_CODE_SHOW_OPTIONS_SETTING.java
@@ -1,5 +1,6 @@
 package org.nico.ratel.landlords.client.event;
 
+import org.nico.ratel.landlords.client.entity.User;
 import org.nico.ratel.landlords.enums.ClientEventCode;
 import org.nico.ratel.landlords.helper.PokerHelper;
 import org.nico.ratel.landlords.print.SimplePrinter;
@@ -20,7 +21,7 @@ public class ClientEventListener_CODE_SHOW_OPTIONS_SETTING extends ClientEventLi
 		SimplePrinter.printNotice("5. Unicode Cards");
 
 		SimplePrinter.printNotice("Please select an option above (enter [BACK] to return to options list)");
-		String line = SimpleWriter.write("setting");
+		String line = SimpleWriter.write(User.INSTANCE.getNickname(), "setting");
 
 		if (line.equalsIgnoreCase("BACK")) {
 			get(ClientEventCode.CODE_SHOW_OPTIONS).call(channel, data);

--- a/landlords-client/src/main/java/org/nico/ratel/landlords/client/proxy/ProtobufProxy.java
+++ b/landlords-client/src/main/java/org/nico/ratel/landlords/client/proxy/ProtobufProxy.java
@@ -12,14 +12,14 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import io.netty.handler.timeout.IdleStateHandler;
-import org.nico.ratel.landlords.client.handler.SecondProtobufCodec;
 import org.nico.ratel.landlords.client.handler.ProtobufTransferHandler;
+import org.nico.ratel.landlords.client.handler.SecondProtobufCodec;
 import org.nico.ratel.landlords.entity.ClientTransferData;
 import org.nico.ratel.landlords.print.SimplePrinter;
 
 import java.util.concurrent.TimeUnit;
 
-public class ProtobufProxy implements Proxy{
+public class ProtobufProxy implements Proxy {
     @Override
     public void connect(String serverAddress, int port) throws InterruptedException {
         EventLoopGroup group = new NioEventLoopGroup();

--- a/landlords-common/src/main/java/org/nico/ratel/landlords/print/SimpleWriter.java
+++ b/landlords-common/src/main/java/org/nico/ratel/landlords/print/SimpleWriter.java
@@ -12,9 +12,9 @@ public class SimpleWriter {
 		return write("player", message);
 	}
 
-	public static String write(String user, String message) {
+	public static String write(String nickname, String message) {
 		System.out.println();
-		System.out.printf("[%s:ratel@%s]$ ", user, message);
+		System.out.printf("[%s@%s]$ ", nickname, message);
 		try {
 			return write();
 		} finally {

--- a/landlords-common/src/main/java/org/nico/ratel/landlords/print/SimpleWriter.java
+++ b/landlords-common/src/main/java/org/nico/ratel/landlords/print/SimpleWriter.java
@@ -9,8 +9,12 @@ public class SimpleWriter {
 	private static final BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
 
 	public static String write(String message) {
+		return write("player", message);
+	}
+
+	public static String write(String user, String message) {
 		System.out.println();
-		System.out.print("[ratel@" + message + "]$ ");
+		System.out.printf("[%s:ratel@%s]$ ", user, message);
 		try {
 			return write();
 		} finally {


### PR DESCRIPTION
Hi All,
    It is a meaningless pr about adding the nickname to terminal.
    1. The format is `[{nickname}:ratel@{message}]`
    2. The init nickname is `player`
    3. When send the `CODE_CLIENT_NICKNAME_SET` event, client will save the nickname to User.INSTANCE

Regards,
Goody

P.S.: It is my first time to pr. If there are something uncomfortable, please feel free to connect me.